### PR TITLE
Fix api-augment build error. fix #17

### DIFF
--- a/packages/api-augment/src/index.ts
+++ b/packages/api-augment/src/index.ts
@@ -1,3 +1,3 @@
-import "./interfaces/types-lookup";
-import "./interfaces/augment-api";
-import "./interfaces/augment-types";
+import "./interfaces/types-lookup.js";
+import "./interfaces/augment-api.js";
+import "./interfaces/augment-types.js";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,10 +1,10 @@
 import { jsonrpcFromDefs, typesFromDefs } from '@open-web3/orml-type-definitions/utils';
 
-import automationTime from './automationTime'
-import xcmpHandler from './xcmpHandler'
+import automationTime from './automationTime.js'
+import xcmpHandler from './xcmpHandler.js'
 
-export * from './automationTime'
-export * from './xcmpHandler'
+export * from './automationTime.js'
+export * from './xcmpHandler.js'
 
 const extractFromDefs = (defs: any, keyItem: string) => {
   const items: Record<string, any> = {};


### PR DESCRIPTION
I have publish test package at https://www.npmjs.com/package/@imstar15/api-augment/v/1.9.0-rc.3, 
and test successfuly with https://github.com/novasamatech/subquery-staking

The changes refers to https://github.com/PureStake/moonbeam/blob/19889514e6bd5f0f7e3b307e0e68b4c59df872ca/typescript-api/src/moonbeam/index.ts#L1


Minimal use case:

_package.json_
```
{
  "name": "test-api",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "start": "node index.js"
  },
  "dependencies": {
    "@imstar15/api-augment": "^1.9.0-rc.3",
    "@imstar15/types": "^1.9.0-rc.3",
    "@babel/runtime": "^7.20.13"
  },
  "author": "",
  "license": "ISC"
}
```

Note:
`"@babel/runtime": "^7.20.13"` is usually a dependency of `"@polkadot/api"`, so it doesn't need to be specified separately.

_index.js_
```
require("@oak-network/api-augment");
console.log(require("@oak-network/types"));
```

**Launch, node version >= 14**
```
npm install
npm start
```

**Log:**
```
> test-api@1.0.0 start
> node index.js

{
  definitions: {
    automationTime: { rpc: [Object], types: [Object], runtime: [Object] },
    xcmpHandler: { rpc: [Object], types: {}, runtime: [Object] }
  },
  types: {
    AutomationAction: { _enum: [Array] },
    AutostakingResult: { period: 'i32', apy: 'f64' },
    AutomationFeeDetails: { executionFee: 'Balance', xcmpFee: 'Balance' }
  },
  rpc: {
    automationTime: {
      generateTaskId: [Object],
      getTimeAutomationFees: [Object],
      calculateOptimalAutostaking: [Object],
      getAutoCompoundDelegatedStakeTaskIds: [Object],
      queryFeeDetails: [Object]
    },
    xcmpHandler: { crossChainAccount: [Object], fees: [Object] }
  },
  runtime: { AutomationTimeApi: [ [Object] ], XcmpHandlerApi: [ [Object] ] }
}
```
