### PR TITLE
remove generate generate_task_id typedef in xcmp handler

### DIFF
--- a/packages/api-augment/src/interfaces/xcmpHandler/runtime.ts
+++ b/packages/api-augment/src/interfaces/xcmpHandler/runtime.ts
@@ -4,11 +4,6 @@ export const runtime: DefinitionsCall = {
   XcmpHandlerApi: [
     {
       methods: {
-        generate_task_id: {
-          description: 'Find xcmp account id',
-          params: [{ name: 'accountId', type: 'AccountId32' }],
-          type: 'AccountId32'
-        },
         get_time_automation_fees: {
           description: 'Determine fees for a scheduled xcmp task',
           params: [{ name: 'encodedXt', type: 'Bytes' }],


### PR DESCRIPTION
I missed this in previous PR https://github.com/OAK-Foundation/oak.js/pull/21 when commit the code