### PR TITLE
Fix build directory incorrect problem during dev version publish

### DIFF
--- a/.github/workflows/npm-publish-dev.yml
+++ b/.github/workflows/npm-publish-dev.yml
@@ -42,5 +42,5 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTOMATION_TOKEN_CHRIS }}" > ~/.npmrc
 
       - name: 🚀 Publish ${{ matrix.package }} package
-        working-directory: ./packages/${{ matrix.package }}
+        working-directory: ./packages/${{ matrix.package }}/build
         run: npm publish --tag dev


### PR DESCRIPTION
The old publish script cd into build folder so this action didn’t set the right directory without /build
```
for package in $(ls packages); do
  cd packages/$package/build
  npm pkg set version=$version
  npm publish $tag_option --otp $otp
  cd -
```