### PR TITLE
Fix a blocking usage issue in config package caused by node:util

### DIFF
--- a/.changeset/fifty-cherries-move.md
+++ b/.changeset/fifty-cherries-move.md
@@ -1,0 +1,5 @@
+---
+"@oak-network/sdk-types": patch
+---
+
+Fix a usage error casued by the reference of node:util

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build": "npm exec -- tsc --build tsconfig.build.json",
     "postbuild": "scripts/package-setup",
     "clean": "npm exec -- tsc --build --clean tsconfig.build.json",
-    "publish": "bash scripts/publish",
     "test": "npm run build && jest --verbose --forceExit --runInBand ./test/functional",
     "test:sdk": "npm run build && jest --verbose --runInBand ./test/sdk",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oak.js",
   "version": "2.0.0-rc.1",
   "repository": "https://github.com/oak-foundation/oak.js",
-  "author": "OAK Team <contact@oak.tech>",
+  "author": "OAK Team <developer@oak.tech>",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {

--- a/packages/sdk-types/src/types.ts
+++ b/packages/sdk-types/src/types.ts
@@ -1,4 +1,3 @@
-import util from 'node:util';
 import BN from 'bn.js';
 
 export type relayChainType = 'local' | 'rococo' | 'moonbase-alpha-relay' | 'kusama' | 'polkadot';
@@ -20,7 +19,7 @@ export class Weight {
     return new Weight(this.refTime.add(weight.refTime), this.proofSize.add(weight.proofSize));
   }
 
-  [util.inspect.custom]() {
+  toString() {
     const { refTime, proofSize } = this;
     return `Weight { refTime: ${refTime.toString()}, proofSize: ${proofSize.toString()} }`;
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,6 @@
   "main": "./build/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@open-web3/orml-type-definitions": "^2.0.1",
-    "ts-loader": "^9.4.4"
+    "@open-web3/orml-type-definitions": "^2.0.1"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,6 +4,7 @@
   "main": "./build/index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@open-web3/orml-type-definitions": "^2.0.1"
+    "@open-web3/orml-type-definitions": "^2.0.1",
+    "ts-loader": "^9.4.4"
   }
 }


### PR DESCRIPTION
# Problem
When using @oak-network/config as an imported npm library, we encounter the below error.

Cause:
`import { chains } from '@oak-network/config';`

Error:
```
ModuleBuildError: Module build failed: UnhandledSchemeError: Reading from "node:util" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
```

# Solution
The problem is caused by a line of code in another package, @oak-network/sdk-types. Removing the reference of "node:util" fixed the problem.