### PR TITLE
Return different instruction numbers based on the transactType

### DIFF
--- a/packages/adapter/src/chains/oak.ts
+++ b/packages/adapter/src/chains/oak.ts
@@ -12,7 +12,10 @@ import { getDerivativeAccountV2, sendExtrinsic } from "../util";
 import { SendExtrinsicResult } from "../types";
 import { WEIGHT_REF_TIME_PER_SECOND } from "../constants";
 
-const TRANSACT_XCM_INSTRUCTION_COUNT = 4;
+export enum OakAdapterTransactType {
+  PayThroughRemoteDerivativeAccount,
+  PayThroughSoverignAccount,
+}
 
 // OakAdapter implements ChainAdapter
 export class OakAdapter extends ChainAdapter {
@@ -140,10 +143,18 @@ export class OakAdapter extends ChainAdapter {
 
   /**
    * Get the instruction number of XCM instructions for transact
+   * In the xcmp-handler, there are two processes for sending XCM instructions.
+   * PayThroughRemoteDerivativeAccount requires 4 XCM instructions,
+   * PayThroughSovereignAccount requires 6 instructions.
+   * @param transactType
+   * @returns The instruction number of XCM instructions
    */
   // eslint-disable-next-line class-methods-use-this
-  getTransactXcmInstructionCount() {
-    return TRANSACT_XCM_INSTRUCTION_COUNT;
+  getTransactXcmInstructionCount(transactType: OakAdapterTransactType) {
+    return transactType ===
+      OakAdapterTransactType.PayThroughRemoteDerivativeAccount
+      ? 4
+      : 6;
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,6 +10,7 @@ import {
   OakAdapter,
   TaskSchedulerChainAdapter,
   SendExtrinsicResult,
+  OakAdapterTransactType,
 } from "@oak-network/adapter";
 import { Weight } from "@oak-network/config";
 
@@ -124,7 +125,10 @@ const scheduleXcmpTaskWithPayThroughRemoteDerivativeAccountFlow = async (
   const destination = { V3: destinationChainAdapter.getLocation() };
   const encodedCall = taskPayloadExtrinsic.method.toHex();
   const oakTransactXcmInstructionCount =
-    xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount();
+    xcmOptions?.instructionCount ||
+    oakAdapter.getTransactXcmInstructionCount(
+      OakAdapterTransactType.PayThroughRemoteDerivativeAccount,
+    );
   const taskPayloadEncodedCallWeight =
     await destinationChainAdapter.getExtrinsicWeight(
       taskPayloadExtrinsic,
@@ -339,7 +343,9 @@ export function Sdk() {
       const encodedCall = taskPayloadExtrinsic.method.toHex();
       const oakTransactXcmInstructionCount =
         xcmOptions?.instructionCount ||
-        oakAdapter.getTransactXcmInstructionCount();
+        oakAdapter.getTransactXcmInstructionCount(
+          OakAdapterTransactType.PayThroughSoverignAccount,
+        );
       const taskPayloadEncodedCallWeight =
         await destinationChainAdapter.getExtrinsicWeight(
           taskPayloadExtrinsic,


### PR DESCRIPTION
In the xcmp-handler, there are two processes for sending XCM instructions.
- PayThroughRemoteDerivativeAccount requires 4 XCM instructions. [Link](https://github.com/OAK-Foundation/OAK-blockchain/blob/8dadfbada3f2df998f1420860d620a3aaf1e932b/pallets/xcmp-handler/src/lib.rs#L380-L389)
- PayThroughSovereignAccount requires 6 instructions. [Link](https://github.com/OAK-Foundation/OAK-blockchain/blob/8dadfbada3f2df998f1420860d620a3aaf1e932b/pallets/xcmp-handler/src/lib.rs#L325-L342)