### PR TITLE
Added currencyId to tokens of Turing chains

### DIFF
--- a/.changeset/dirty-wasps-visit.md
+++ b/.changeset/dirty-wasps-visit.md
@@ -1,0 +1,5 @@
+---
+"@oak-network/config": patch
+---
+
+Added currency Id to the tokens registered on Turing chains

--- a/.changeset/sharp-jokes-rush.md
+++ b/.changeset/sharp-jokes-rush.md
@@ -1,5 +1,0 @@
----
-"@oak-network/adapter": patch
----
-
-Export utils constants and errors from adapters

--- a/.changeset/sharp-jokes-rush.md
+++ b/.changeset/sharp-jokes-rush.md
@@ -1,0 +1,5 @@
+---
+"@oak-network/adapter": patch
+---
+
+Export utils constants and errors from adapters

--- a/packages/config/src/chains/dev.ts
+++ b/packages/config/src/chains/dev.ts
@@ -18,8 +18,10 @@ const shibuya = createChain({
 
 const turingLocal = createChain({
   assets: [
-    { asset: DevTokens.tur, isNative: true },
-    { asset: DevTokens.sby, isNative: false },
+    { asset: DevTokens.tur, id: 0, isNative: true },
+    { asset: DevTokens.sby, id: 4, isNative: false },
+    { asset: DevTokens.moonbaseLocal, id: 5, isNative: false },
+    { asset: DevTokens.mgr, id: 1, isNative: false },
   ],
   endpoint: "ws://127.0.0.1:9946",
   key: "turing-local",

--- a/packages/config/src/chains/kusama.ts
+++ b/packages/config/src/chains/kusama.ts
@@ -18,10 +18,10 @@ const shiden = createChain({
 
 const turing = createChain({
   assets: [
-    { asset: KusamaTokens.tur, isNative: true },
-    { asset: KusamaTokens.sdn, isNative: false },
-    { asset: KusamaTokens.movr, isNative: false },
-    { asset: KusamaTokens.mgx, isNative: false },
+    { asset: KusamaTokens.tur, id: 0, isNative: true },
+    { asset: KusamaTokens.sdn, id: 8, isNative: false },
+    { asset: KusamaTokens.movr, id: 9, isNative: false },
+    { asset: KusamaTokens.mgx, isNative: false }, // MGX is not registered on Turing yet
   ],
   endpoint: "wss://rpc.turing.oak.tech",
   key: "turing",

--- a/packages/config/src/chains/rococo.ts
+++ b/packages/config/src/chains/rococo.ts
@@ -33,8 +33,8 @@ const mangataRococo = createChain({
 
 const turingStaging = createChain({
   assets: [
-    { asset: RococoTokens.tur, isNative: true },
-    { asset: RococoTokens.rstr, isNative: false },
+    { asset: RococoTokens.tur, id: 0, isNative: true },
+    { asset: RococoTokens.rstr, id: 9, isNative: false },
   ],
   endpoint: "wss://rpc.turing-staging.oak.tech",
   key: "turing-staging",

--- a/packages/config/src/chains/types/Chain.ts
+++ b/packages/config/src/chains/types/Chain.ts
@@ -13,6 +13,7 @@ interface XcmConfig {
 type AssetInfo = {
   asset: Token;
   isNative: boolean;
+  id?: number;
 };
 
 interface ChainConstructorParams {


### PR DESCRIPTION
These values are needed for transfer non-native tokens via `currencies.transfer`