### PR TITLE
Add callerXcmFeeLocation param to scheduleXcmpTaskWithPayThroughRemoteDerivativeAccountFlow function

### DIFF
--- a/.changeset/violet-scissors-cross.md
+++ b/.changeset/violet-scissors-cross.md
@@ -1,0 +1,6 @@
+---
+"@oak-network/adapter": patch
+"@oak-network/sdk": patch
+---
+
+Add callerXcmFeeLocation param to scheduleXcmpTaskWithPayThroughRemoteDerivativeAccountFlow function

--- a/packages/adapter/src/chains/moonbeam.ts
+++ b/packages/adapter/src/chains/moonbeam.ts
@@ -22,13 +22,7 @@ export class MoonbeamAdapter extends ChainAdapter implements TaskScheduler {
    * Initialize adapter
    */
   async initialize() {
-    // As of 12/02/2023, api.consts and api.query both return {} from all Moonriver endpoints.
-    // Maybe additional calls are required prior to fetch api.consts
-
-    // await this.fetchAndUpdateConfigs();
-
-    this.chainConfig.ss58Prefix = 1285;
-    this.chainConfig.paraId = 2023;
+    await this.fetchAndUpdateConfigs();
   }
 
   /**

--- a/packages/adapter/src/chains/oak.ts
+++ b/packages/adapter/src/chains/oak.ts
@@ -242,6 +242,7 @@ export class OakAdapter extends ChainAdapter {
       encodedCall,
       encodedCallWeight,
       overallWeight,
+      "PayThroughSovereignAccount",
     );
 
     console.log(`Send extrinsic from ${key} to schedule task. extrinsic:`, extrinsic.method.toHex());

--- a/packages/adapter/src/chains/oak.ts
+++ b/packages/adapter/src/chains/oak.ts
@@ -25,8 +25,8 @@ export interface AutomationPriceTriggerParams {
 }
 
 export enum OakAdapterTransactType {
-  PayThroughRemoteDerivativeAccount,
-  PayThroughSoverignAccount,
+  PayThroughRemoteDerivativeAccount = "PayThroughRemoteDerivativeAccount",
+  PayThroughSoverignAccount = "PayThroughSoverignAccount",
 }
 
 // OakAdapter implements ChainAdapter
@@ -209,27 +209,36 @@ export class OakAdapter extends ChainAdapter {
   }
 
   /**
-   * Schedule XCMP task
-   * @param destination The location of the destination chain
-   * @param schedule Schedule setting
-   * @param scheduleFee Schedule fee
-   * @param executionFee Execution fee
-   * @param encodedCall Encoded call
-   * @param encodedCallWeight The encoded call weight weight of the XCM instructions
-   * @param overallWeight The overall weight of the XCM instructions
+   * Schedule AutomationTime XCMP task
+   * @param schedule The schedule of the task
+   * @param xcmParams The parameters of the XCM instructions
+   * destination - The location of the destination chain
+   * schedule - Schedule setting
+   * scheduleFee - Schedule fee
+   * executionFee - Execution fee
+   * encodedCall -  Encoded call
+   * encodedCallWeight - The encoded call weight weight of the XCM instructions
+   * overallWeight - The overall weight of the XCM instructions
+   * transactType - Transact type
+   * scheduleAs - The real executor of the task
    * @param keyringPair Operator's keyring pair
    * @returns SendExtrinsicResult
    */
-  async scheduleXcmpTask(
-    destination: any,
+  async scheduleAutomationTimeXcmpTask(
     schedule: any,
-    scheduleFee: any,
-    executionFee: any,
-    encodedCall: HexString,
-    encodedCallWeight: Weight,
-    overallWeight: Weight,
+    xcmParams: {
+      destination: any;
+      scheduleFee: any;
+      executionFee: any;
+      encodedCall: HexString;
+      encodedCallWeight: Weight;
+      overallWeight: Weight;
+      transactType: OakAdapterTransactType;
+    },
+    scheduleAs: HexString | undefined,
     keyringPair: KeyringPair,
   ): Promise<SendExtrinsicResult> {
+    const { destination, scheduleFee, executionFee, encodedCall, encodedCallWeight, overallWeight, transactType } = xcmParams;
     const api = this.getApi();
     const { key } = this.chainConfig;
     if (_.isUndefined(key)) throw new Error("chainConfig.key not set");
@@ -242,7 +251,8 @@ export class OakAdapter extends ChainAdapter {
       encodedCall,
       encodedCallWeight,
       overallWeight,
-      "PayThroughSovereignAccount",
+      transactType,
+      scheduleAs,
     );
 
     console.log(`Send extrinsic from ${key} to schedule task. extrinsic:`, extrinsic.method.toHex());
@@ -251,39 +261,45 @@ export class OakAdapter extends ChainAdapter {
   }
 
   /**
-   * Schedule XCMP task
-   * @param destination The location of the destination chain
-   * @param schedule Schedule setting
-   * @param scheduleFee Schedule fee
-   * @param executionFee Execution fee
-   * @param encodedCall Encoded call
-   * @param encodedCallWeight The encoded call weight weight of the XCM instructions
-   * @param overallWeight The overall weight of the XCM instructions
+   * Schedule AutomationPrice XCMP task
+   * @param triggerParams The trigger params of the task
+   * @param xcmParams The parameters of the XCM instructions
+   * destination - The location of the destination chain
+   * schedule - Schedule setting
+   * scheduleFee - Schedule fee
+   * executionFee - Execution fee
+   * encodedCall -  Encoded call
+   * encodedCallWeight - The encoded call weight weight of the XCM instructions
+   * overallWeight - The overall weight of the XCM instructions
    * @param keyringPair Operator's keyring pair
    * @returns SendExtrinsicResult
    */
-  async scheduleXcmpPriceTask(
-    automationPriceTriggerParams: AutomationPriceTriggerParams,
-    destination: any,
-    scheduleFee: any,
-    executionFee: any,
-    encodedCall: HexString,
-    encodedCallWeight: Weight,
-    overallWeight: Weight,
+  async scheduleAutomationPriceXcmpTask(
+    triggerParams: AutomationPriceTriggerParams,
+    xcmParams: {
+      destination: any;
+      scheduleFee: any;
+      executionFee: any;
+      encodedCall: HexString;
+      encodedCallWeight: Weight;
+      overallWeight: Weight;
+    },
     keyringPair: KeyringPair,
   ): Promise<SendExtrinsicResult> {
+    const { destination, scheduleFee, executionFee, encodedCall, encodedCallWeight, overallWeight } = xcmParams;
     const api = this.getApi();
     const { key } = this.chainConfig;
     if (_.isUndefined(key)) throw new Error("chainData.key not set");
 
+    const { chain, exchange, asset1, asset2, submittedAt, triggerFunction, triggerParam } = triggerParams;
     const extrinsic = api.tx.automationPrice.scheduleXcmpTask(
-      automationPriceTriggerParams.chain,
-      automationPriceTriggerParams.exchange,
-      automationPriceTriggerParams.asset1,
-      automationPriceTriggerParams.asset2,
-      automationPriceTriggerParams.submittedAt,
-      automationPriceTriggerParams.triggerFunction,
-      automationPriceTriggerParams.triggerParam,
+      chain,
+      exchange,
+      asset1,
+      asset2,
+      submittedAt,
+      triggerFunction,
+      triggerParam,
       destination,
       scheduleFee,
       executionFee,

--- a/packages/adapter/src/chains/oak.ts
+++ b/packages/adapter/src/chains/oak.ts
@@ -24,7 +24,7 @@ export interface AutomationPriceTriggerParams {
   triggerParam: number[];
 }
 
-export enum OakAdapterTransactType {
+export enum InstructionSequenceType {
   PayThroughRemoteDerivativeAccount = "PayThroughRemoteDerivativeAccount",
   PayThroughSoverignAccount = "PayThroughSoverignAccount",
 }
@@ -204,8 +204,8 @@ export class OakAdapter extends ChainAdapter {
    * @returns The instruction number of XCM instructions
    */
   // eslint-disable-next-line class-methods-use-this
-  getTransactXcmInstructionCount(transactType: OakAdapterTransactType) {
-    return transactType === OakAdapterTransactType.PayThroughRemoteDerivativeAccount ? 4 : 6;
+  getTransactXcmInstructionCount(instructionSequenceType: InstructionSequenceType) {
+    return instructionSequenceType === InstructionSequenceType.PayThroughRemoteDerivativeAccount ? 4 : 6;
   }
 
   /**
@@ -233,12 +233,12 @@ export class OakAdapter extends ChainAdapter {
       encodedCall: HexString;
       encodedCallWeight: Weight;
       overallWeight: Weight;
-      transactType: OakAdapterTransactType;
+      instructionSequenceType: InstructionSequenceType;
     },
     scheduleAs: HexString | undefined,
     keyringPair: KeyringPair,
   ): Promise<SendExtrinsicResult> {
-    const { destination, scheduleFee, executionFee, encodedCall, encodedCallWeight, overallWeight, transactType } = xcmParams;
+    const { destination, scheduleFee, executionFee, encodedCall, encodedCallWeight, overallWeight, instructionSequenceType } = xcmParams;
     const api = this.getApi();
     const { key } = this.chainConfig;
     if (_.isUndefined(key)) throw new Error("chainConfig.key not set");
@@ -251,7 +251,7 @@ export class OakAdapter extends ChainAdapter {
       encodedCall,
       encodedCallWeight,
       overallWeight,
-      transactType,
+      instructionSequenceType,
       scheduleAs,
     );
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,7 @@ import {
   OakAdapter,
   TaskSchedulerChainAdapter,
   SendExtrinsicResult,
-  OakAdapterTransactType,
+  InstructionSequenceType,
   AutomationPriceTriggerParams,
 } from "@oak-network/adapter";
 import { Weight } from "@oak-network/config";
@@ -79,7 +79,7 @@ const scheduleXcmpTaskWithPayThroughRemoteDerivativeAccountFlow = async (
   const destination = { V3: destinationChainAdapter.getLocation() };
   const encodedCall = taskPayloadExtrinsic.method.toHex();
   const oakTransactXcmInstructionCount =
-    xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(OakAdapterTransactType.PayThroughRemoteDerivativeAccount);
+    xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(InstructionSequenceType.PayThroughRemoteDerivativeAccount);
   const taskPayloadEncodedCallWeight = await destinationChainAdapter.getExtrinsicWeight(taskPayloadExtrinsic, keyringPair);
   const taskPayloadOverallWeight =
     xcmOptions?.overallWeight ||
@@ -159,7 +159,7 @@ export function Sdk() {
       const destination = { V3: destinationChainAdapter.getLocation() };
       const encodedCall = taskPayloadExtrinsic.method.toHex();
       const oakTransactXcmInstructionCount =
-        xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(OakAdapterTransactType.PayThroughSoverignAccount);
+        xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(InstructionSequenceType.PayThroughSoverignAccount);
       const taskPayloadEncodedCallWeight = await destinationChainAdapter.getExtrinsicWeight(taskPayloadExtrinsic, keyringPair);
       const taskPayloadOverallWeight =
         xcmOptions?.overallWeight ||
@@ -222,7 +222,7 @@ export function Sdk() {
       const destination = { V3: destinationChainAdapter.getLocation() };
       const encodedCall = taskPayloadExtrinsic.method.toHex();
       const oakTransactXcmInstructionCount =
-        xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(OakAdapterTransactType.PayThroughSoverignAccount);
+        xcmOptions?.instructionCount || oakAdapter.getTransactXcmInstructionCount(InstructionSequenceType.PayThroughSoverignAccount);
       const taskPayloadEncodedCallWeight = await destinationChainAdapter.getExtrinsicWeight(taskPayloadExtrinsic, keyringPair);
       const taskPayloadOverallWeight =
         xcmOptions?.overallWeight ||
@@ -242,9 +242,9 @@ export function Sdk() {
           encodedCall,
           encodedCallWeight: taskPayloadEncodedCallWeight,
           executionFee,
+          instructionSequenceType: InstructionSequenceType.PayThroughSoverignAccount,
           overallWeight: taskPayloadOverallWeight,
           scheduleFee: { V3: scheduleFeeLocation },
-          transactType: OakAdapterTransactType.PayThroughSoverignAccount,
         },
         undefined,
         keyringPair,

--- a/packages/sdk/src/task-builder/AutomationPriceTaskBuilder.ts
+++ b/packages/sdk/src/task-builder/AutomationPriceTaskBuilder.ts
@@ -1,0 +1,40 @@
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { AutomationPriceTriggerParams } from "@oak-network/adapter";
+import { CreateTaskParams, TaskBuilder } from "./TaskBuilder";
+
+/**
+ * AutomationPriceTaskBuilder is a class that implements TaskBuilder interface to build AutomationPrice task
+ */
+class AutomationPriceTaskBuilder extends TaskBuilder {
+  triggerParams: AutomationPriceTriggerParams;
+
+  constructor(triggerParams: AutomationPriceTriggerParams) {
+    super();
+    this.triggerParams = triggerParams;
+  }
+
+  createTask(params: CreateTaskParams): SubmittableExtrinsic<"promise"> {
+    const { oakApi, destination, encodedCall, encodedCallWeight, overallWeight, scheduleFeeLocation, executionFee, scheduleAs } = params;
+    const { chain, exchange, asset1, asset2, submittedAt, triggerFunction, triggerParam } = this.triggerParams;
+    const taskExtrinsic = oakApi.tx.automationPrice.scheduleXcmpTaskThroughProxy(
+      chain,
+      exchange,
+      asset1,
+      asset2,
+      submittedAt,
+      triggerFunction,
+      triggerParam,
+      destination,
+      { V3: scheduleFeeLocation },
+      executionFee,
+      encodedCall,
+      encodedCallWeight,
+      overallWeight,
+      "PayThroughRemoteDerivativeAccount",
+      scheduleAs,
+    );
+    return taskExtrinsic;
+  }
+}
+
+export { AutomationPriceTaskBuilder };

--- a/packages/sdk/src/task-builder/AutomationTimeTaskBuilder.ts
+++ b/packages/sdk/src/task-builder/AutomationTimeTaskBuilder.ts
@@ -1,0 +1,32 @@
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { CreateTaskParams, TaskBuilder } from "./TaskBuilder";
+
+/**
+ * AutomationTimeTaskBuilder is a class that implements TaskBuilder interface to build AutomationTime task
+ */
+class AutomationTimeTaskBuilder extends TaskBuilder {
+  schedule: any;
+
+  constructor(schedule: any) {
+    super();
+    this.schedule = schedule;
+  }
+
+  createTask(params: CreateTaskParams): SubmittableExtrinsic<"promise"> {
+    const { oakApi, destination, encodedCall, encodedCallWeight, overallWeight, scheduleFeeLocation, executionFee, scheduleAs } = params;
+    const taskExtrinsic = oakApi.tx.automationTime.scheduleXcmpTask(
+      this.schedule,
+      destination,
+      { V3: scheduleFeeLocation },
+      executionFee,
+      encodedCall,
+      encodedCallWeight,
+      overallWeight,
+      "PayThroughRemoteDerivativeAccount",
+      scheduleAs,
+    );
+    return taskExtrinsic;
+  }
+}
+
+export { AutomationTimeTaskBuilder };

--- a/packages/sdk/src/task-builder/TaskBuilder.ts
+++ b/packages/sdk/src/task-builder/TaskBuilder.ts
@@ -1,0 +1,24 @@
+import { Weight } from "@oak-network/config";
+import type { ApiPromise } from "@polkadot/api";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { HexString } from "@polkadot/util/types";
+
+interface CreateTaskParams {
+  oakApi: ApiPromise;
+  destination: any;
+  encodedCall: HexString;
+  encodedCallWeight: Weight;
+  overallWeight: Weight;
+  scheduleFeeLocation: any;
+  executionFee: any;
+  scheduleAs: HexString | undefined;
+}
+
+/**
+ * TaskBuilder is an abstract class that defines the interface for building tasks
+ */
+abstract class TaskBuilder {
+  abstract createTask(params: CreateTaskParams): SubmittableExtrinsic<"promise">;
+}
+
+export { TaskBuilder, CreateTaskParams };

--- a/packages/sdk/src/task-builder/index.ts
+++ b/packages/sdk/src/task-builder/index.ts
@@ -1,0 +1,3 @@
+export * from "./TaskBuilder";
+export * from "./AutomationTimeTaskBuilder";
+export * from "./AutomationPriceTaskBuilder";


### PR DESCRIPTION
1. Add `callerXcmFeeLocation` param to `scheduleXcmpTaskWithPayThroughRemoteDerivativeAccountFlow` function
2. Extract the task-building functionality into `TaskBuilder`