### PR TITLE
Replace moonriver endpoint

### DIFF
--- a/.changeset/hungry-bananas-sit.md
+++ b/.changeset/hungry-bananas-sit.md
@@ -1,0 +1,5 @@
+---
+"@oak-network/config": patch
+---
+
+Replace moonriver endpoint

--- a/packages/config/src/chains/kusama.ts
+++ b/packages/config/src/chains/kusama.ts
@@ -61,7 +61,7 @@ const moonriver = createChain({
       isNative: false,
     },
   ],
-  endpoint: "wss://wss.api.moonriver.moonbeam.network",
+  endpoint: "wss://moonriver.public.blastapi.io",
   family: ChainFamily.moonbeam,
   isEthereum: true,
   key: "moonriver",


### PR DESCRIPTION
The automation-hub app can't access the RPC endpoint with `ethers.JsonRpcProvider`

Test preview in This PR:
https://github.com/AvaProtocol/automation-hub/pull/249

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/442160d0-ae23-4d9d-9994-209f8587ecbc">
